### PR TITLE
Fix code generator for double and float fields with [default=nan]

### DIFF
--- a/compiler-plugin/src/main/scala/com/trueaccord/scalapb/compiler/ProtobufGenerator.scala
+++ b/compiler-plugin/src/main/scala/com/trueaccord/scalapb/compiler/ProtobufGenerator.scala
@@ -107,11 +107,13 @@ class ProtobufGenerator(val params: GeneratorParams) extends DescriptorPimps {
         val f = defaultValue.asInstanceOf[Float]
         if (f.isPosInfinity) "Float.PositiveInfinity"
         else if (f.isNegInfinity) "Float.NegativeInfinity"
+        else if (f.isNaN) "Float.NaN"
         else f.toString + "f"
       case FieldDescriptor.JavaType.DOUBLE =>
         val d = defaultValue.asInstanceOf[Double]
         if (d.isPosInfinity) "Double.PositiveInfinity"
         else if (d.isNegInfinity) "Double.NegativeInfinity"
+        else if (d.isNaN) "Double.NaN"
         else d.toString
       case FieldDescriptor.JavaType.BOOLEAN => Boolean.unbox(defaultValue.asInstanceOf[java.lang.Boolean])
       case FieldDescriptor.JavaType.BYTE_STRING => defaultValue.asInstanceOf[ByteString]

--- a/e2e/src/main/protobuf/defaults.proto
+++ b/e2e/src/main/protobuf/defaults.proto
@@ -1,0 +1,15 @@
+package com.trueaccord.proto.e2e;
+
+message DefaultsTest {
+  optional int32 i1 = 2 [default=99];
+
+  optional double d1 = 3 [default=0.0];
+  optional double d2 = 4 [default=inf];
+  optional double d3 = 5 [default=-inf];
+  optional double d4 = 6 [default=nan];  
+
+  optional float f1 = 7 [default=0.0];
+  optional float f2 = 8 [default=inf];
+  optional float f3 = 9 [default=-inf];
+  optional float f4 = 10 [default=nan];  
+}

--- a/e2e/src/test/scala/DefaultsSpec.scala
+++ b/e2e/src/test/scala/DefaultsSpec.scala
@@ -1,0 +1,18 @@
+import com.trueaccord.proto.e2e.defaults._
+import org.scalatest._
+
+class DefaultsSpec extends FlatSpec with MustMatchers {
+  val d = DefaultsTest()
+
+  "defaults" should "be set correctly" in {
+    d.d1.isEmpty must be(true)
+    d.getD1 must be(0.0)
+    d.getD2.isPosInfinity must be(true)
+    d.getD3.isNegInfinity must be(true)
+    d.getD4.isNaN must be(true)
+    d.getF1 must be(0.0f)
+    d.getF2.isPosInfinity must be(true)
+    d.getF3.isNegInfinity must be(true)
+    d.getF4.isNaN must be(true)
+  }
+}


### PR DESCRIPTION
nan is a valid default value, but ScalaPB generates code that doesn't compile if it is used.

Thanks for a great tool.