### PR TITLE
make generated toString use printToUnicodeString

### DIFF
--- a/compiler-plugin/src/main/scala/com/trueaccord/scalapb/compiler/ProtobufGenerator.scala
+++ b/compiler-plugin/src/main/scala/com/trueaccord/scalapb/compiler/ProtobufGenerator.scala
@@ -860,7 +860,7 @@ class ProtobufGenerator(val params: GeneratorParams) extends DescriptorPimps {
     }
       .call(generateGetField(message))
       .when(message.javaConversions)(
-        _.add(s"override def toString: String = com.google.protobuf.TextFormat.printToString(${message.scalaTypeName}.toJavaProto(this))"))
+        _.add(s"override def toString: String = com.google.protobuf.TextFormat.printToUnicodeString(${message.scalaTypeName}.toJavaProto(this))"))
       .add(s"def companion = ${message.scalaTypeName}")
       .outdent
       .outdent


### PR DESCRIPTION
printToString escapes all non-ASCII characters with ordinals, which is terrible for debugging non-English text. For Issue #41.