### PR TITLE
call asSymbol in fullJavaName

### DIFF
--- a/compiler-plugin/src/main/scala/com/trueaccord/scalapb/compiler/DescriptorPimps.scala
+++ b/compiler-plugin/src/main/scala/com/trueaccord/scalapb/compiler/DescriptorPimps.scala
@@ -271,7 +271,7 @@ trait DescriptorPimps {
       }
 
     def fullJavaName(fullName: String) = {
-      javaFullOuterClassName + "." + stripPackageName(fullName)
+      javaFullOuterClassName + "." + stripPackageName(fullName).asSymbol
     }
 
     def fileDescriptorObjectName = snakeCaseToCamelCase(file.getName, upperInitial = true)

--- a/e2e/src/main/protobuf/names.dot.proto
+++ b/e2e/src/main/protobuf/names.dot.proto
@@ -30,3 +30,6 @@ message WeirdNamesRequired {
   required string tag = 2;
   required Option option = 3;
 }
+
+message yield {
+}


### PR DESCRIPTION
if without this fix

https://travis-ci.org/xuwei-k/ScalaPB/jobs/88728473#L760
https://github.com/xuwei-k/ScalaPB/commit/a9a93d7e4d759e0

```
[error] /home/travis/build/xuwei-k/ScalaPB/e2e/target/scala-2.10/src_managed/main/compiled_protobuf/name_test/names/dot/yield.scala:38: identifier expected but 'yield' found.
[error] object `yield` extends com.trueaccord.scalapb.GeneratedMessageCompanion[`yield`] with com.trueaccord.scalapb.JavaProtoSupport[`yield`, name_test.NamesDot.yield]  {
[error]                                                                                                                                                           ^
[error] /home/travis/build/xuwei-k/ScalaPB/e2e/target/scala-2.10/src_managed/main/compiled_protobuf/name_test/names/dot/yield.scala:39: identifier expected but 'yield' found.
[error]   implicit def messageCompanion: com.trueaccord.scalapb.GeneratedMessageCompanion[`yield`] with com.trueaccord.scalapb.JavaProtoSupport[`yield`, name_test.NamesDot.yield]  = this
[error]                                                                                                                                                                     ^
[error] /home/travis/build/xuwei-k/ScalaPB/e2e/target/scala-2.10/src_managed/main/compiled_protobuf/name_test/names/dot/yield.scala:40: identifier expected but 'yield' found.
[error]   def toJavaProto(scalaPbSource: name_test.names.dot.`yield`): name_test.NamesDot.yield = {
[error]                                                                                   ^
[error] /home/travis/build/xuwei-k/ScalaPB/e2e/target/scala-2.10/src_managed/main/compiled_protobuf/name_test/names/dot/yield.scala:44: illegal start of simple expression
[error]   def fromJavaProto(javaPbSource: name_test.NamesDot.yield): name_test.names.dot.`yield` = name_test.names.dot.`yield`(
[error] ^
[error] /home/travis/build/xuwei-k/ScalaPB/e2e/target/scala-2.10/src_managed/main/compiled_protobuf/name_test/names/dot/yield.scala:44: identifier expected but 'yield' found.
[error]   def fromJavaProto(javaPbSource: name_test.NamesDot.yield): name_test.names.dot.`yield` = name_test.names.dot.`yield`(
[error]                                                      ^
[error] 5 errors found
```