### PR TITLE
Target JDK 1.7

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -8,6 +8,8 @@ scalaVersion in ThisBuild := "2.11.7"
 
 crossScalaVersions in ThisBuild := Seq("2.10.6", "2.11.7", "2.12.0-M1")
 
+scalacOptions in ThisBuild += "-target:jvm-1.7"
+
 organization in ThisBuild := "com.trueaccord.scalapb"
 
 profileName := "com.trueaccord"


### PR DESCRIPTION
The codebase is not using any JDK 1.8 features. This ensures that when compiling with JDK 1.8, the artifacts produced are compatible with 1.7.