### PR TITLE
target java7

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -8,7 +8,19 @@ scalaVersion in ThisBuild := "2.11.7"
 
 crossScalaVersions in ThisBuild := Seq("2.10.6", "2.11.7", "2.12.0-M1")
 
-scalacOptions in ThisBuild += "-target:jvm-1.7"
+scalacOptions in ThisBuild ++= {
+  CrossVersion.partialVersion(scalaVersion.value) match {
+    case Some((2, v)) if v <= 11 => List("-target:jvm-1.7")
+    case _ => Nil
+  }
+}
+
+javacOptions in ThisBuild ++= {
+  CrossVersion.partialVersion(scalaVersion.value) match {
+    case Some((2, v)) if v <= 11 => List("-target", "7", "-source", "7")
+    case _ => Nil
+  }
+}
 
 organization in ThisBuild := "com.trueaccord.scalapb"
 


### PR DESCRIPTION
https://github.com/trueaccord/ScalaPB/pull/52 is not enough because

- there are some java files in ScalaPB
- does not support `-target:jvm-1.7` option Scala 2.12.0-M2 or later