### PR TITLE
GeneratedEnum and GeneratedOneof extends Product

### DIFF
--- a/scalapb-runtime/shared/src/main/scala/com/trueaccord/scalapb/GeneratedMessageCompanion.scala
+++ b/scalapb-runtime/shared/src/main/scala/com/trueaccord/scalapb/GeneratedMessageCompanion.scala
@@ -8,7 +8,7 @@ import scala.collection.JavaConversions._
 
 import scala.util.Try
 
-trait GeneratedEnum extends Serializable {
+trait GeneratedEnum extends Product with Serializable {
   type EnumType <: GeneratedEnum
 
   def value: Int
@@ -31,7 +31,7 @@ trait GeneratedEnumCompanion[A <: GeneratedEnum] {
   def descriptor: EnumDescriptor
 }
 
-trait GeneratedOneof extends Serializable {
+trait GeneratedOneof extends Product with Serializable {
   def number: Int
 }
 


### PR DESCRIPTION
before

```
scala> import com.trueaccord.proto.e2e.one_of.OneofTest
import com.trueaccord.proto.e2e.one_of.OneofTest

scala> List(OneofTest.MyOneOf.Empty, OneofTest.MyOneOf.Sub(OneofTest.SubMessage()))
res0: List[com.trueaccord.proto.e2e.one_of.OneofTest.MyOneOf with Product] = List(Empty, Sub())

scala> import com.trueaccord.proto.e2e.enum3.Color3
import com.trueaccord.proto.e2e.enum3.Color3

scala> Color3.values
res1: Seq[com.trueaccord.proto.e2e.enum3.Color3 with Product] = List(C3_UNKNOWN, C3_RED, C3_GREEN, C3_BLUE)

scala> List(Color3.C3_RED, Color3.C3_BLUE)
res2: List[com.trueaccord.proto.e2e.enum3.Color3 with Product] = List(C3_RED, C3_BLUE)
```

after

```
scala> import com.trueaccord.proto.e2e.one_of.OneofTest
import com.trueaccord.proto.e2e.one_of.OneofTest

scala> List(OneofTest.MyOneOf.Empty, OneofTest.MyOneOf.Sub(OneofTest.SubMessage()))
res0: List[com.trueaccord.proto.e2e.one_of.OneofTest.MyOneOf] = List(Empty, Sub())

scala> import com.trueaccord.proto.e2e.enum3.Color3
import com.trueaccord.proto.e2e.enum3.Color3

scala> Color3.values
res1: Seq[com.trueaccord.proto.e2e.enum3.Color3] = List(C3_UNKNOWN, C3_RED, C3_GREEN, C3_BLUE)

scala> List(Color3.C3_RED, Color3.C3_BLUE)
res2: List[com.trueaccord.proto.e2e.enum3.Color3] = List(C3_RED, C3_BLUE)
```

same fix in Scala std library
- https://github.com/scala/scala/commit/da6ef7b7d4cfd4849499e28c7f0f6
- https://github.com/scala/scala/commit/226c4df186150d7773fa7cd9ad68