### PR TITLE
remove `javaConversions = true` when grpc

### DIFF
--- a/compiler-plugin/src/main/scala/com/trueaccord/scalapb/compiler/ProtobufGenerator.scala
+++ b/compiler-plugin/src/main/scala/com/trueaccord/scalapb/compiler/ProtobufGenerator.scala
@@ -997,7 +997,7 @@ object ProtobufGenerator {
     params.split(",").map(_.trim).filter(_.nonEmpty).foldLeft[Either[String, GeneratorParams]](Right(GeneratorParams())) {
       case (Right(params), "java_conversions") => Right(params.copy(javaConversions = true))
       case (Right(params), "flat_package") => Right(params.copy(flatPackage = true))
-      case (Right(params), "grpc") => Right(params.copy(grpc = true, javaConversions = true))
+      case (Right(params), "grpc") => Right(params.copy(grpc = true))
       case (Right(params), p) => Left(s"Unrecognized parameter: '$p'")
       case (x, _) => x
     }

--- a/e2e/build.sbt
+++ b/e2e/build.sbt
@@ -59,7 +59,7 @@ PB.protocOptions in PB.protobufConfig := {
   val conf = (PB.generatedTargets in PB.protobufConfig).value
   val scalaOpts = conf.find(_._2.endsWith(".scala")) match {
     case Some(targetForScala) =>
-      Seq(s"--scala_out=grpc:${targetForScala._1.absolutePath}")
+      Seq(s"--scala_out=grpc,java_conversions:${targetForScala._1.absolutePath}")
     case None =>
       Nil
   }


### PR DESCRIPTION
I added `javaConversions = true` because my first implementation use `toJavaProto` and `fromJavaProto` methods.
Because of `com.trueaccord.scalapb.grpc.Marshaller` 59e9fd5393809cf6d5ad973, no longer need javaConversions!