### PR TITLE
use fully qualified name. s/Any/scala.Any

### DIFF
--- a/compiler-plugin/src/main/scala/com/trueaccord/scalapb/compiler/ProtobufGenerator.scala
+++ b/compiler-plugin/src/main/scala/com/trueaccord/scalapb/compiler/ProtobufGenerator.scala
@@ -246,7 +246,7 @@ class ProtobufGenerator(val params: GeneratorParams) extends DescriptorPimps {
     }
 
   def generateGetField(message: Descriptor)(fp: FunctionalPrinter) = {
-    val signature = "def getField(__field: com.google.protobuf.Descriptors.FieldDescriptor): Any = "
+    val signature = "def getField(__field: com.google.protobuf.Descriptors.FieldDescriptor): scala.Any = "
     if (message.getFields.nonEmpty)
         fp.add(signature + "{")
           .indent
@@ -592,7 +592,7 @@ class ProtobufGenerator(val params: GeneratorParams) extends DescriptorPimps {
         toCustomTypeExpr(field)
 
     val myFullScalaName = message.scalaTypeName
-    printer.add(s"def fromFieldsMap(__fieldsMap: Map[com.google.protobuf.Descriptors.FieldDescriptor, Any]): $myFullScalaName = {")
+    printer.add(s"def fromFieldsMap(__fieldsMap: Map[com.google.protobuf.Descriptors.FieldDescriptor, scala.Any]): $myFullScalaName = {")
       .indent
       .add("require(__fieldsMap.keys.forall(_.getContainingType() == descriptor), \"FieldDescriptor does not match message type.\")")
       .add("val __fields = descriptor.getFields")

--- a/e2e/src/main/protobuf/names.dot.proto
+++ b/e2e/src/main/protobuf/names.dot.proto
@@ -33,3 +33,6 @@ message WeirdNamesRequired {
 
 message yield {
 }
+
+message Any {
+}


### PR DESCRIPTION
I want to use `google/protobuf/any.proto`

https://github.com/google/protobuf/blob/v3.0.0-beta-1/src/google/protobuf/any.proto

```
[error] target/scala-2.11/src_managed/main/compiled_protobuf/com/google/protobuf/any/Any.scala:60: type mismatch;
[error]  found   : String
[error]  required: com.google.protobuf.any.Any
[error]         case 1 => typeUrl
[error]                   ^
[error] target/scala-2.11/src_managed/main/compiled_protobuf/com/google/protobuf/any/Any.scala:61: type mismatch;
[error]  found   : com.google.protobuf.ByteString
[error]  required: com.google.protobuf.any.Any
[error]         case 2 => value
[error]                   ^
[error] two errors found
```