### PR TITLE
Fix double stream close, don't call onComplete after onError

### DIFF
--- a/scalapb-runtime-grpc/src/main/scala/com/trueaccord/scalapb/grpc/Grpc.scala
+++ b/scalapb-runtime-grpc/src/main/scala/com/trueaccord/scalapb/grpc/Grpc.scala
@@ -22,6 +22,5 @@ object Grpc {
       observer.onCompleted()
     case scala.util.Failure(error) =>
       observer.onError(error)
-      observer.onCompleted()
   }
 }


### PR DESCRIPTION
Fixes #71