### PR TITLE
Add implicit value for the companion object of enums

### DIFF
--- a/compiler-plugin/src/main/scala/com/trueaccord/scalapb/compiler/ProtobufGenerator.scala
+++ b/compiler-plugin/src/main/scala/com/trueaccord/scalapb/compiler/ProtobufGenerator.scala
@@ -26,6 +26,7 @@ class ProtobufGenerator(val params: GeneratorParams) extends DescriptorPimps {
       .add("")
       .add(s"object $name extends com.trueaccord.scalapb.GeneratedEnumCompanion[$name] {")
       .indent
+      .add(s"implicit def enumCompanion: com.trueaccord.scalapb.GeneratedEnumCompanion[$name] = this")
       .print(e.getValues) {
       case (v, p) => p.addM(
         s"""@SerialVersionUID(0L)

--- a/e2e/src/test/scala/EnumSpec.scala
+++ b/e2e/src/test/scala/EnumSpec.scala
@@ -1,5 +1,6 @@
 import com.trueaccord.proto.e2e.enum._
 import com.trueaccord.proto.e2e.enum3._
+import com.trueaccord.scalapb.GeneratedEnumCompanion
 import org.scalatest._
 
 class EnumSpec extends FlatSpec with MustMatchers {
@@ -107,6 +108,10 @@ class EnumSpec extends FlatSpec with MustMatchers {
     e3.getColor must be (Color.Unrecognized(18))
     e3.getColor must not be (Color.Unrecognized(19))
     e3.toByteArray must be (like.toByteArray)
+  }
+
+  "color companion" should "be available implicitly" in {
+    implicitly[GeneratedEnumCompanion[Color]] must be (Color)
   }
 
 }


### PR DESCRIPTION
This makes it possible to implicitly get the companion object of an enum, like it's currently possible to do for the companion object of messages.