### PR TITLE
change method descriptor from private to public

### DIFF
--- a/compiler-plugin/src/main/scala/com/trueaccord/scalapb/compiler/GrpcServicePrinter.scala
+++ b/compiler-plugin/src/main/scala/com/trueaccord/scalapb/compiler/GrpcServicePrinter.scala
@@ -151,7 +151,7 @@ final class GrpcServicePrinter(service: ServiceDescriptor, override val params: 
     val grpcMethodDescriptor = "_root_.io.grpc.MethodDescriptor"
 
     p.addM(
-      s"""private[this] val ${method.descriptorName}: $grpcMethodDescriptor[${method.scalaIn}, ${method.scalaOut}] =
+      s"""val ${method.descriptorName}: $grpcMethodDescriptor[${method.scalaIn}, ${method.scalaOut}] =
           |  $grpcMethodDescriptor.create(
           |    $grpcMethodDescriptor.MethodType.$methodType,
           |    $grpcMethodDescriptor.generateFullMethodName("${service.getFullName}", "${method.getName}"),


### PR DESCRIPTION
grpc-java generates method descriptor as `public`.
And it is used in official example. 
https://github.com/grpc/grpc-java/blob/v0.13.2/examples/src/main/java/io/grpc/examples/experimental/CompressingHelloWorldClient.java#L79

ScalaPB genarates method descriptor as `private[this]`.
so I want to chage it to `public`

Here is the generated code
grpc-java(v0.13.2): https://gist.github.com/matsu-chara/d75d5a1ce93d9280be03#file-greetergrpc-java-L25-L32 
ScalaPB(v0.5.22): https://gist.github.com/matsu-chara/d75d5a1ce93d9280be03#file-greetergrpc-scala-L5-L10