### PR TITLE
depend not on grpc-all, but on more fine-grained dependencies

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -95,7 +95,7 @@ lazy val grpcRuntime = project.in(file("scalapb-runtime-grpc"))
   .settings(
     name := "scalapb-runtime-grpc",
     libraryDependencies ++= Seq(
-      "io.grpc" % "grpc-all" % grpcVersion
+      "io.grpc" % "grpc-stub" % grpcVersion
     )
   )
 
@@ -132,7 +132,7 @@ lazy val proptest = project.in(file("proptest"))
       libraryDependencies ++= Seq(
         "com.github.os72" % "protoc-jar" % "3.0.0-b2",
         "com.google.protobuf" % "protobuf-java" % "3.0.0-beta-2",
-        "io.grpc" % "grpc-all" % grpcVersion % "test",
+        "io.grpc" % "grpc-netty" % grpcVersion % "test",
         "com.trueaccord.lenses" %% "lenses" % "0.4.1",
         "com.trueaccord.scalapb" %% "scalapb-json4s" % "0.1.1",
         "org.scalacheck" %% "scalacheck" % "1.12.4" % "test",

--- a/e2e/build.sbt
+++ b/e2e/build.sbt
@@ -22,7 +22,8 @@ val grpcArtifactId = "protoc-gen-grpc-java"
 
 libraryDependencies ++= Seq(
   "org.scalatest" %% "scalatest" % "2.2.1" % "test",
-  "io.grpc" % "grpc-all" % grpcVersion,
+  "io.grpc" % "grpc-netty" % grpcVersion, //netty transport of grpc
+  "io.grpc" % "grpc-protobuf" % grpcVersion, //protobuf message encoding for java implementation
   "org.scalacheck" %% "scalacheck" % "1.12.4" % "test",
   "com.trueaccord.scalapb" %% "scalapb-runtime-grpc" % com.trueaccord.scalapb.Version.scalapbVersion,
   "com.trueaccord.scalapb" %% "scalapb-runtime" % com.trueaccord.scalapb.Version.scalapbVersion % PB.protobufConfig,


### PR DESCRIPTION
fixes #113 

Need to fix docs as well by introducing explicit dependency on a transport, otherwise default examples will stop working.