### PR TITLE
fixes #121: java serialization breaks serializedSize

### DIFF
--- a/e2e/src/main/protobuf/repeatables.proto
+++ b/e2e/src/main/protobuf/repeatables.proto
@@ -11,6 +11,14 @@ message RepeatablesTest {
     repeated int32 ints = 2;
     repeated double doubles = 3 [packed = true];
     repeated Nested nesteds = 4;
+    repeated int64 packedLongs = 6 [packed = true];
+
+    enum Enum {
+      ONE = 1;
+      TWO = 2;
+    }
+
+    repeated Enum enums = 7 [packed = true];
 
     message Nested {
         optional int32 nested_field = 1;

--- a/e2e/src/test/scala/JavaSerializationSpec.scala
+++ b/e2e/src/test/scala/JavaSerializationSpec.scala
@@ -1,0 +1,57 @@
+
+import java.io.{ByteArrayInputStream, ByteArrayOutputStream, ObjectInputStream, ObjectOutputStream}
+
+import com.trueaccord.proto.e2e.repeatables.RepeatablesTest
+import com.trueaccord.proto.e2e.repeatables.RepeatablesTest.Nested
+import com.trueaccord.scalapb.GeneratedMessage
+import org.scalacheck.{Arbitrary, Gen}
+import org.scalatest._
+import org.scalatest.prop._
+
+class JavaSerializationSpec extends FlatSpec with GeneratorDrivenPropertyChecks with MustMatchers {
+
+  val nestedGen =
+    Arbitrary.arbitrary[Option[Int]].map(s => Nested(nestedField = s))
+
+  val oneEnum = Gen.choose(0, 1).map(i => RepeatablesTest.Enum.fromValue(i))
+
+  val repGen = for {
+    strings <- Gen.listOf(Arbitrary.arbitrary[String])
+    ints <- Gen.listOf(Arbitrary.arbitrary[Int])
+    doubles <- Gen.listOf(Arbitrary.arbitrary[Double])
+    nesteds <- Gen.listOf(nestedGen)
+    longs <- Gen.listOf(Arbitrary.arbitrary[Long])
+    enums <- Gen.listOf(oneEnum)
+  } yield RepeatablesTest(
+    strings = strings, ints = ints, doubles = doubles,
+    nesteds = nesteds, packedLongs = longs, enums = enums
+  )
+
+  def checkJavaSerialization[T <: GeneratedMessage](a: T) = {
+    val baos = new ByteArrayOutputStream()
+    val oos = new ObjectOutputStream(baos)
+
+    val inputA = a.companion.parseFrom(a.toByteArray)
+
+    oos.writeObject(inputA)
+    oos.close()
+
+    val ois = new ObjectInputStream(new ByteArrayInputStream(baos.toByteArray))
+    val b = ois.readObject().asInstanceOf[T]
+    val abytes = a.toByteArray
+    val bbytes = b.toByteArray
+
+    abytes mustBe bbytes
+  }
+
+  "fromJson" should "invert toJson (single)" in {
+    val rep = RepeatablesTest(strings=Seq("s1", "s2"), ints=Seq(14, 19), doubles=Seq(3.14, 2.17), nesteds=Seq(Nested()))
+    checkJavaSerialization(rep)
+  }
+
+  "fromJson" should "invert toJson" in {
+    forAll(repGen) {
+      rep => checkJavaSerialization(rep)
+    }
+  }
+}


### PR DESCRIPTION
 Previously -1 was used as a sentinel value.
 However, if a generated case class to be serialized using java serialization,
 all backing fields would be reset to 0 because java serialization does not call
 constructors.

 This fix changes serializedSize default (sentinel) value to 0.
 Serialized size of 0 is valid value and it will not be cached if the message
 is actually empty.
 Still, for such messages computing size should be cheap.