### PR TITLE
Fully qualify Map/Seq types in generated code.

### DIFF
--- a/compiler-plugin/src/main/scala/com/trueaccord/scalapb/compiler/DescriptorPimps.scala
+++ b/compiler-plugin/src/main/scala/com/trueaccord/scalapb/compiler/DescriptorPimps.scala
@@ -156,7 +156,7 @@ trait DescriptorPimps {
 
     def typeCategory(base: String): String = {
       if (supportsPresence) s"scala.Option[$base]"
-      else if (fd.isRepeated) s"Seq[$base]"
+      else if (fd.isRepeated) s"scala.collection.Seq[$base]"
       else base
     }
 
@@ -300,7 +300,7 @@ trait DescriptorPimps {
 
       def valueType = valueField.singleScalaTypeName
 
-      def scalaTypeName = s"Map[$keyType, $valueType]"
+      def scalaTypeName = s"scala.collection.immutable.Map[$keyType, $valueType]"
 
       def pairType = s"($keyType, $valueType)"
     }


### PR DESCRIPTION
Map/Seq need to be fully qualified to avoid interfering with messages
named Map/Seq. In my case, I have a Map (as in cartography) protocol
buffer message. Compiling generated code that uses the Map message
results in compilation messsage such as

```
[error] /home/liam/work/strava/metro/metro-interface/target/scala-2.11/src_managed/main/compiled_protobuf/com/strava/metro/protobuf/map/Edge.scala:85: com.strava.metro.protobuf.map.Map does not take type parameters
[error]   def fromFieldsMap(__fieldsMap: Map[com.google.protobuf.Descriptors.FieldDescriptor, scala.Any]): com.strava.metro.protobuf.map.Edge = {
[error]                                  ^
```

I have tested this out locally with my problematic protobuf code. e2e also works. Is there anything else testing-wise that might be needed?