### PR TITLE
Adding jade

### DIFF
--- a/examples/build.sbt
+++ b/examples/build.sbt
@@ -1,3 +1,5 @@
+import ScalateKeys._
+
 scalaVersion := "2.11.8"
 
 PB.targets in Compile := Seq(
@@ -9,3 +11,14 @@ libraryDependencies ++= Seq(
   "com.trueaccord.scalapb" %% "scalapb-runtime" % "0.5.42" % "protobuf"
 )
 
+seq(scalateSettings:_*)
+
+scalateTemplateConfig in Compile <<= (sourceDirectory in Compile){ base =>
+  Seq(
+    TemplateConfig(
+      base / "resources" / "templates",
+      Nil,
+      Nil
+    )
+  )
+}

--- a/examples/project/plugins.sbt
+++ b/examples/project/plugins.sbt
@@ -1,0 +1,3 @@
+logLevel := Level.Warn
+
+addSbtPlugin("com.mojolly.scalate" % "xsbt-scalate-generator" % "0.5.0")

--- a/examples/src/main/resources/templates/test.jade
+++ b/examples/src/main/resources/templates/test.jade
@@ -1,0 +1,6 @@
+doctype html
+html
+  head
+    title my jade template
+  body
+    h1 Hello


### PR DESCRIPTION
Adding this code results in "is already defined as" error on jade generated code. Do you know why?

examples > sbt compile
[info] Loading global plugins from /Users/rjonna/.sbt/0.13/plugins
[info] Loading project definition from /Users/rjonna/source/play/grpc/ScalaPB/examples/project
[info] Set current project to examples (in build file:/Users/rjonna/source/play/grpc/ScalaPB/examples/)
[info] Compiling Templates in Template Directory: /Users/rjonna/source/play/grpc/ScalaPB/examples/src/main/resources/templates
SLF4J: Failed to load class "org.slf4j.impl.StaticLoggerBinder".
SLF4J: Defaulting to no-operation (NOP) logger implementation
SLF4J: See http://www.slf4j.org/codes.html#StaticLoggerBinder for further details.
[info] Compiling 9 Scala sources to /Users/rjonna/source/play/grpc/ScalaPB/examples/target/scala-2.11/classes...
[error] /Users/rjonna/source/play/grpc/ScalaPB/examples/target/scala-2.11/src_managed/main/scalate/templates/test_jade.scala:4: $_scalate_$test_jade is already defined as object $_scalate_$test_jade
[error] object $_scalate_$test_jade {
[error]        ^
[error] /Users/rjonna/source/play/grpc/ScalaPB/examples/target/scala-2.11/src_managed/main/scalate/templates/test_jade.scala:18: $_scalate_$test_jade is already defined as class $_scalate_$test_jade
[error] class $_scalate_$test_jade extends _root_.org.fusesource.scalate.Template {
[error]       ^
[error] two errors found
[error] (compile:compile) Compilation failed
[error] Total time: 1 s, completed Oct 19, 2016 3:18:22 PM